### PR TITLE
<title> tag formatting

### DIFF
--- a/header.php
+++ b/header.php
@@ -27,7 +27,7 @@ elseif( is_search() ) :
   echo 'Search for &quot;' . wp_specialchars( $s ) . '&quot; -';
 
 // if !404 and single or page
-elseif( !( is_404() ) && ( is_single() ) || ( is_page() ) ) :
+elseif( !( is_404() ) && ( is_single() ) || ( is_page() ) && !(is_front_page() ) ) :
   esc_attr( wp_title( '' ) ); echo '-';
 
 // if 404


### PR DESCRIPTION
Seems that when I set a Page to be the front page of a Wordpress install, the title of the page appears as:

`- Name of Site`

and I can't quite figure out how to remove the prepending dash by looking at the php inside the `<title>` tags in `header.php`
