### PR TITLE
fix prepending dash in title element when a custom Page is set to the homepage

### DIFF
--- a/header.php
+++ b/header.php
@@ -27,7 +27,7 @@ elseif( is_search() ) :
   echo 'Search for &quot;' . wp_specialchars( $s ) . '&quot; -';
 
 // if !404 and single or page
-elseif( !( is_404() ) && ( is_single() ) || ( is_page() ) ) :
+elseif( !( is_404() ) && ( is_single() ) || ( is_page() ) && !(is_front_page() ) ) :
   esc_attr( wp_title( '' ) ); echo '-';
 
 // if 404


### PR DESCRIPTION
Seems that this condition was firing as well as the one below it that checked for is_home and is_front_page, and was throwing in a dash. Why the later condition wasn't overwriting this one, who knows.
